### PR TITLE
Hide style formatting warnings in zed

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -37,5 +37,25 @@
     "vue": true,
     "dockerfile": true,
     "docker-compose": true
+  },
+  "lsp": {
+    "eslint": {
+      "settings": {
+        "rulesCustomizations": [
+          {
+            "rule": "style/*",
+            "severity": "off"
+          },
+          {
+            "rule": "*-{indent,spacing,spaces,order,dangle,newline}",
+            "severity": "off"
+          },
+          {
+            "rule": "*{quotes,semi}",
+            "severity": "off"
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Такое уже есть для VS Code. Так как включено автоформатирование при сохранение нет смысла видеть, где лишний пробел или где скобочка не там стоит.