### PR TITLE
Disable vtsls formatter in zed settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -9,7 +9,7 @@
         "tailwindcss-language-server",
         "..."
       ],
-      "formatter": "language_server",
+      "formatter": [],
       "prettier": { "allowed": false },
       "code_actions_on_format": {
         "source.fixAll.eslint": true
@@ -17,7 +17,7 @@
     },
     "TypeScript": {
       "language_servers": ["vtsls", "eslint"],
-      "formatter": "language_server",
+      "formatter": [],
       "prettier": { "allowed": false },
       "code_actions_on_format": {
         "source.fixAll.eslint": true
@@ -25,7 +25,7 @@
     },
     "JavaScript": {
       "language_servers": ["vtsls", "eslint"],
-      "formatter": "language_server",
+      "formatter": [],
       "prettier": { "allowed": false },
       "code_actions_on_format": {
         "source.fixAll.eslint": true


### PR DESCRIPTION
Оставляет только `eslint --fix`.