### PR TITLE
Fix handling of steamcommunity links

### DIFF
--- a/backend/src/modules/records-providers/records-providers.service.ts
+++ b/backend/src/modules/records-providers/records-providers.service.ts
@@ -36,7 +36,7 @@ export class RecordsProvidersService {
       parse: m => m[1],
     },
     steam: {
-      regex: /store\.steampowered\.com\/app\/(\d+)|steamcommunity\.com\/app\/(\d+)/,
+      regex: /(?:store\.steampowered|steamcommunity)\.com\/app\/(\d+)/,
       parse: m => Number(m[1]),
     },
     imdb: {


### PR DESCRIPTION
Ссылки в виде `https://steamcommunity.com/app/105600` не работали.