### PR TITLE
Add vtsls to Zed language servers for Vue.js

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -8,36 +8,36 @@
         "vue-language-server",
         "vtsls",
         "tailwindcss-language-server",
-        "..."
+        "...",
       ],
       "formatter": [],
       "prettier": { "allowed": false },
       "code_actions_on_format": {
-        "source.fixAll.eslint": true
-      }
+        "source.fixAll.eslint": true,
+      },
     },
     "TypeScript": {
       "language_servers": ["vtsls", "eslint"],
       "formatter": [],
       "prettier": { "allowed": false },
       "code_actions_on_format": {
-        "source.fixAll.eslint": true
-      }
+        "source.fixAll.eslint": true,
+      },
     },
     "JavaScript": {
       "language_servers": ["vtsls", "eslint"],
       "formatter": [],
       "prettier": { "allowed": false },
       "code_actions_on_format": {
-        "source.fixAll.eslint": true
-      }
-    }
+        "source.fixAll.eslint": true,
+      },
+    },
   },
   "auto_install_extensions": {
     "html": true,
     "vue": true,
     "dockerfile": true,
-    "docker-compose": true
+    "docker-compose": true,
   },
   "lsp": {
     "eslint": {
@@ -45,18 +45,18 @@
         "rulesCustomizations": [
           {
             "rule": "style/*",
-            "severity": "off"
+            "severity": "off",
           },
           {
             "rule": "*-{indent,spacing,spaces,order,dangle,newline}",
-            "severity": "off"
+            "severity": "off",
           },
           {
             "rule": "*{quotes,semi}",
-            "severity": "off"
-          }
-        ]
-      }
-    }
-  }
+            "severity": "off",
+          },
+        ],
+      },
+    },
+  },
 }


### PR DESCRIPTION
Это включает тайпскрипт lsp в vue файлах. Странно, что "..." не включили его.